### PR TITLE
Fix: Column names with spaces in Turbo and Full Text Search for Turbo

### DIFF
--- a/powerbase-server/app/lib/powerbase/query_compiler.rb
+++ b/powerbase-server/app/lib/powerbase/query_compiler.rb
@@ -687,9 +687,9 @@ module Powerbase
 
         if search_query != nil && search_query.length > 0
           if query_string.length > 0
-            "*:(#{sanitize(search_query)}) AND (#{query_string})"
+            "*:\"#{sanitize(search_query)}\" AND (#{query_string})"
           else
-            "*:(#{sanitize(search_query)})"
+            "*:\"#{sanitize(search_query)}\""
           end
         else
           query_string

--- a/powerbase-server/app/lib/powerbase/query_compiler.rb
+++ b/powerbase-server/app/lib/powerbase/query_compiler.rb
@@ -230,7 +230,7 @@ module Powerbase
           search_params[:script_fields][field_name.to_sym] = {
             script: {
               lang: "painless",
-              source: "if (params._source.#{field_name} != null && params._source.#{field_name}.length() > 40) { return params._source.#{field_name}.substring(0, 40) } else { return params._source.#{field_name} }",
+              source: "if (params._source[\"#{field_name}\"] != null && params._source[\"#{field_name}\"].length() > 40) { return params._source[\"#{field_name}\"].substring(0, 40) } else { return params._source[\"#{field_name}\"] }",
             },
           }
         end
@@ -249,7 +249,7 @@ module Powerbase
           search_params[:script_fields][field_name.to_sym] = {
             script: {
               lang: "painless",
-              source: "if (params._source.#{field_name} != null && params._source.#{field_name}.length() > #{text_size}) { return params._source.#{field_name}.substring(0, #{text_size}) } else { return params._source.#{field_name} }",
+              source: "if (params._source[\"#{field_name}\"] != null && params._source[\"#{field_name}\"].length() > #{text_size}) { return params._source[\"#{field_name}\"].substring(0, #{text_size}) } else { return params._source[\"#{field_name}\"] }",
             },
           }
         end
@@ -257,7 +257,7 @@ module Powerbase
         search_params[:script_fields]["#{field_name}_count".to_sym] = {
           script: {
             lang: "painless",
-            source: "if (params._source.#{field_name}_count != null) { return params._source.#{field_name}_count } else { return null }",
+            source: "if (params._source[\"#{field_name}_count\"] != null) { return params._source[\"#{field_name}_count\"] } else { return null }",
           },
         }
       end


### PR DESCRIPTION
## Description

- Before, there was a problem in querying column with spaces on their name for turbo bases, in this PR, that has been fixed by using the bracket notation rather than dot notation.
- Before, the full text search just search whether a record contains a given words, now it must contains the exact phrase.
